### PR TITLE
Implement C# sign in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # CAU Network Auto Sign-In (C#)
 
-This repository provides a simple console application that performs an automatic sign-in request to a network portal. It was rewritten in C# based on the Kotlin implementation.
+This project provides a C# console application that mirrors the behaviour of the Kotlin version for automatically logging into the CAU network.
 
 ## Usage
 
-1. Set the environment variables `CAU_USERNAME` and `CAU_PASSWORD` with your credentials.
-2. Build the project with a C# compiler or open it in your preferred IDE.
-3. Run the program. It will attempt to send a POST request to the sign-in endpoint.
+1. Set the environment variables `CAU_USERNAME` and `CAU_PASSWORD` or supply them via command line options.
+2. Build the project with the .NET SDK.
+3. Run the application:
+   ```
+   dotnet run --project AutoSignIn.csproj -- --url=https://example.com/login
+   ```
+   Optional arguments:
+   * `--username=<name>` – overrides `CAU_USERNAME`
+   * `--password=<pass>` – overrides `CAU_PASSWORD`
+   * `--url=<endpoint>` – sign-in endpoint (default `https://example.com/login`)
 
-The sign-in URL in `Program.cs` is a placeholder (`https://example.com/login`). Update it to the actual CAU network login endpoint.
+The actual sign-in URL must be replaced with the real CAU network portal endpoint.

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,46 +1,39 @@
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace AutoSignIn
 {
     class Program
     {
-        static async Task Main(string[] args)
+        static async Task<int> Main(string[] args)
         {
-            string username = Environment.GetEnvironmentVariable("CAU_USERNAME") ?? "";
-            string password = Environment.GetEnvironmentVariable("CAU_PASSWORD") ?? "";
-            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
+            string? username = null;
+            string? password = null;
+            string url = "https://example.com/login";
+
+            foreach (var arg in args)
             {
-                Console.Error.WriteLine("Please set CAU_USERNAME and CAU_PASSWORD environment variables.");
-                return;
+                if (arg.StartsWith("--username="))
+                    username = arg.Substring("--username=".Length);
+                else if (arg.StartsWith("--password="))
+                    password = arg.Substring("--password=".Length);
+                else if (arg.StartsWith("--url="))
+                    url = arg.Substring("--url=".Length);
             }
 
-            try
+            username ??= Environment.GetEnvironmentVariable("CAU_USERNAME");
+            password ??= Environment.GetEnvironmentVariable("CAU_PASSWORD");
+
+            if (string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password))
             {
-                using (var client = new HttpClient())
-                {
-                    var content = new FormUrlEncodedContent(new[]
-                    {
-                        new KeyValuePair<string, string>("username", username),
-                        new KeyValuePair<string, string>("password", password)
-                    });
-                    // The actual sign-in URL may differ; update as needed.
-                    var response = await client.PostAsync("https://example.com/login", content);
-                    if (response.IsSuccessStatusCode)
-                    {
-                        Console.WriteLine("Sign in successful.");
-                    }
-                    else
-                    {
-                        Console.Error.WriteLine($"Sign in failed: {response.StatusCode}");
-                    }
-                }
+                Console.Error.WriteLine("Provide username and password via arguments or environment variables CAU_USERNAME and CAU_PASSWORD.");
+                return 1;
             }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"Error: {ex.Message}");
-            }
+
+            var client = new SignInClient(url);
+            bool success = await client.SignInAsync(username, password);
+            Console.WriteLine(success ? "Sign in successful." : "Sign in failed.");
+            return success ? 0 : 1;
         }
     }
 }

--- a/src/SignInClient.cs
+++ b/src/SignInClient.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace AutoSignIn
+{
+    public class SignInClient
+    {
+        private readonly HttpClient _client = new HttpClient();
+        private readonly string _url;
+
+        public SignInClient(string url)
+        {
+            _url = url;
+        }
+
+        public async Task<bool> SignInAsync(string username, string password)
+        {
+            var content = new FormUrlEncodedContent(new[]
+            {
+                new KeyValuePair<string, string>("username", username),
+                new KeyValuePair<string, string>("password", password)
+            });
+
+            try
+            {
+                var response = await _client.PostAsync(_url, content);
+                return response.IsSuccessStatusCode;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SignInClient` class to perform the login
- update `Program.cs` to parse CLI arguments and call the client
- document usage in `README.md`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860b9cbbe74832db23d66e356b9db30